### PR TITLE
allow to specify particular elements within <td> to limit search to

### DIFF
--- a/jquery.uitablefilter.js
+++ b/jquery.uitablefilter.js
@@ -19,9 +19,9 @@
  *   optional arguments:
  *     array of columns to limit search too (the column title in the table header)
  *     ifHidden - callback to execute if one or more elements was hidden
- *     tdElem - specific element within td to be considered for searching or to limit search to,
- *     default:whole "td". useful if "td" has more than one elements inside but want to 
- *     limit search within only some of elements or only visible elements. eg tdElem can be "td span"  
+ *     tdElem - specific element within <td> to be considered for searching or to limit search to,
+ *     default:whole <td>. useful if <td> has more than one elements inside but want to 
+ *     limit search within only some of elements or only visible elements. eg tdElem can be "td span"
  */
 (function($) {
   $.uiTableFilter = function(jq, phrase, column, ifHidden, tdElem){


### PR DESCRIPTION
Hi, I was using this plugin for table row filter. and Within my table, in each "td" I had text to display as well as some hidden text as well, hidden input "select option" element. So while searching, it was matching the hidden text within "option" tag that I didn't want. 
So I modified the function uiTableFilter to take an additional argument tdElem, that let user to specify a particular elements within "td" to limit the search to. in my case, tdElem was "td span" as i just to wanted to search from text within "td span" elements not "td select" and others.
I think it'll be useful to others as well, so sending the pull request. Please let me know if any concerns. Thanks!
